### PR TITLE
Change name style to allow single character names

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -666,11 +666,11 @@
         </module>
         <module name="LocalFinalVariableName" />
         <module name="LocalVariableName">
-            <property name="format" value="^(id)|([a-z][a-z0-9][a-zA-Z0-9]+)$" />
+            <property name="format" value="^[a-z][a-zA-Z0-9]*$" />
             <property name="allowOneCharVarInForLoop" value="true" />
         </module>
         <module name="MemberName">
-            <property name="format" value="^(id)|([a-z][a-z0-9][a-zA-Z0-9]+)$" />
+            <property name="format" value="^[a-z][a-zA-Z0-9]*$" />
         </module>
         <module name="MethodName" />
         <module name="MethodTypeParameterName">
@@ -678,17 +678,17 @@
         </module>
         <module name="PackageName" />
         <module name="ParameterName">
-            <property name="format" value="^(id)|([a-z][a-z0-9][a-zA-Z0-9]+)$" />
+            <property name="format" value="^[a-z][a-zA-Z0-9]*$" />
             <property name="ignoreOverridden" value="true" />
         </module>
         <module name="LambdaParameterName">
-            <property name="format" value="^(id)|([a-z][a-z0-9][a-zA-Z0-9]+)$" />
+            <property name="format" value="^[a-z][a-zA-Z0-9]*$" />
         </module>
         <module name="CatchParameterName">
             <property name="format" value="^(ex|[a-z][a-z][a-zA-Z]+)$" />
         </module>
         <module name="StaticVariableName">
-            <property name="format" value="^(id)|([a-z][a-z0-9][a-zA-Z0-9]+)$" />
+            <property name="format" value="^[a-z][a-zA-Z0-9]*$" />
         </module>
         <module name="TypeName" />
         <module name="TypeName">


### PR DESCRIPTION
Will now allow names like `x`, `y`, `x1` and `x2` in fields, paramaters and variables.

Note that this also allows names like `a`, `b` and `c`. We should be vigilant when writing and reviewing code to not let bad single-character names get through.