### PR TITLE
Add Automatic releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: Create release with Maven
+
+on:
+  push:
+    branches:    
+      - master
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up JDK 15
+      uses: actions/setup-java@v2
+      with:
+        java-version: '15'
+        distribution: 'adopt'
+        check-latest: false
+        cache: maven
+
+    - name: Package
+      run: mvn package
+
+    - name: Bump version and push tag
+      id: tag_version
+      uses: mathieudutour/github-tag-action@v5
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Rename artifact with version
+      run: cp "target/ColonyManagement.jar" "target/ColonyManagement-${{ steps.tag_version.outputs.new_tag }}.jar"
+
+    - name: Release
+      uses: softprops/action-gh-release@v1
+      with:
+        files: target/ColonyManagement-${{ steps.tag_version.outputs.new_tag }}.jar
+        tag_name: ${{ steps.tag_version.outputs.new_tag }}
+        name: Release ${{ steps.tag_version.outputs.new_tag }}
+        body: ${{ steps.tag_version.outputs.changelog }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,7 @@ jobs:
       uses: mathieudutour/github-tag-action@v5
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
+        default_bump: minor
 
     - name: Rename artifact with version
       run: cp "target/ColonyManagement.jar" "target/ColonyManagement-${{ steps.tag_version.outputs.new_tag }}.jar"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+name: Run Tests With Maven
+
+on:
+  push:
+    branches:    
+      - master
+  pull_request:
+    branches:    
+      - master
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, '[ci skip]')"
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up JDK 15
+      uses: actions/setup-java@v2
+      with:
+        java-version: '15'
+        distribution: 'adopt'
+        check-latest: false
+        cache: maven
+
+    - name: Build and Test
+      run: mvn test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,4 +27,4 @@ jobs:
         cache: maven
 
     - name: Build and Test
-      run: mvn test
+      run: mvn verify

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,0 @@
-language: java
-jdk:
-  - openjdk15


### PR DESCRIPTION
## Summary
Automates the creation of GitHub releases using tags. Versions will be automatically incremented by one minor (0.1.0) version each time a branch is merged into master.

In the release, the source code of the game and the packaged jar file will be included.

### Note
Also switches the CI of the repository from Travis to GitHub workflows, as the automatic releases are also created with them.