### PR TITLE
Add coverage check to maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -176,12 +176,27 @@
                                     <includes>
                                         <include>com.thebois.models.*</include>
                                     </includes>
-                                    <element>BUNDLE</element>
+                                    <element>CLASS</element>
                                     <limits>
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>1.00</minimum>
+                                            <minimum>0.90</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.90</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.90</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>METHOD</counter>
+                                            <value>MISSEDCOUNT</value>
+                                            <maximum>0</maximum>
                                         </limit>
                                         <limit>
                                             <counter>CLASS</counter>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.thebois</groupId>
@@ -153,6 +153,49 @@
                 </dependencies>
             </plugin>
 
+            <!-- Makes sure test coverage is enough -->
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.7</version>
+                <executions>
+                    <execution>
+                        <id>default-prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule>
+                                    <includes>
+                                        <include>com.thebois.models.*</include>
+                                    </includes>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>1.00</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>CLASS</counter>
+                                            <value>MISSEDCOUNT</value>
+                                            <maximum>0</maximum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
             <!-- Compiles -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -177,8 +220,7 @@
                         </goals>
                         <configuration>
                             <transformers>
-                                <transformer
-                                    implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <mainClass>com.thebois.Main</mainClass>
                                 </transformer>
                             </transformers>

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -6,7 +6,10 @@
 [insert screenshot of coverage report of: com.thebois.model.yourmodifiedpackage]
 
 ## Definition of Done
-- [ ] checkboxes to check off the items required to be done
+- [ ] Completed all Tasks of the User Story
+- [ ] The Tasks have tests and they all pass
+- [ ] Overall test coverage is >= 90%
+- [ ] A UML class diagram of the newly implemented User Story is done and included in the README.md of the package
 
 ## Diagrams
 [insert class diagrams and sequence diagrams you have created for the code]

--- a/src/test/java/com/thebois/models/world/WorldTests.java
+++ b/src/test/java/com/thebois/models/world/WorldTests.java
@@ -13,6 +13,7 @@ import org.mockito.Mockito;
 
 import com.thebois.models.Position;
 import com.thebois.models.beings.Colony;
+import com.thebois.models.inventory.IInventory;
 import com.thebois.models.world.structures.IStructure;
 
 import static org.assertj.core.api.Assertions.*;
@@ -52,6 +53,18 @@ public class WorldTests {
                          Arguments.of(new Position(0, -1)),
                          Arguments.of(new Position(0, 3)),
                          Arguments.of(new Position(-1, 3)));
+    }
+
+    @Test
+    public void getColonyInventoryReturnsNotNull() {
+        // Arrange
+        final World world = new World(2, 5);
+
+        // Act
+        final IInventory inventory = world.getColonyInventory();
+
+        // Assert
+        assertThat(inventory).isNotNull();
     }
 
     @Test


### PR DESCRIPTION
## Summary
Formalizes the previously informal DoD-requirement that states that coverage should be above or equal to 90%.

Will fail build if coverage is too low.

To run it locally, use `mvn verify`.

### Other fixes
Also updates our PR template to include the DoD.