### PR TITLE
Hotfix being concurrency issue

### DIFF
--- a/src/test/java/com/thebois/models/beings/ColonyTests.java
+++ b/src/test/java/com/thebois/models/beings/ColonyTests.java
@@ -99,11 +99,12 @@ public class ColonyTests {
     @Test
     public void beingGroupRemovesDeadBeings() {
         // Arrange
+        final float deltaTime = 0.1f;
         final IBeing being = Mockito.mock(IBeing.class);
         final Colony colony = createColony();
         colony.addBeing(being);
+        colony.update(deltaTime);
         final int expectedAmountOfBeings = 0;
-        final float deltaTime = 0.1f;
 
         // Act
         colony.onDeathEvent(new OnDeathEvent(being));


### PR DESCRIPTION
Seems like the `ConcurrentModificationException` of adding new beings still was there after the merge. 

I quickly resolved it by not adding new beings until the next update-loop.